### PR TITLE
.dockstore.yml: Change relative file paths to absolute paths for Dockstore 1.15

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -1,9 +1,9 @@
 version: 1.2
 workflows:
   - subclass: WDL
-    primaryDescriptorPath: BWA_mem.wdl
+    primaryDescriptorPath: /BWA_mem.wdl
     testParameterFiles:
-      - inputs.json
+      - /inputs.json
     authors:
       - name: "Hailey Loucks"
         email: "hloucks@ucsc.edu"


### PR DESCRIPTION
Hello,
I am a software developer at Dockstore and we are approaching our 1.15 release.

Prior to this release, relative paths were being inconsistently and unreliably processed in various parts of our system.
Therefore, in this release, we have more explicitly deprecated the use of relative file paths in our `.dockstore.yml` so all workflows with relative paths will now be deemed as invalid.
Thus, I have created this PR to change the file paths to absolute paths such that your workflows will still be valid after our release.

If you have any questions, please feel free to comment below.

Thank you!
Nayeon - Dockstore